### PR TITLE
Fix referencing labels to open-source conclusions 

### DIFF
--- a/decision-tree.yaml
+++ b/decision-tree.yaml
@@ -763,21 +763,25 @@ questions:
           - nextConclusionId: "12.4"
             if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.5"
-            if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.8"
             if: '"AI-systeem voor algemene doeleinden" in labels && "systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.9"
-            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
+            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.10"
-            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
+            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.11"
             if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.16"
             if: '"AI-model voor algemene doeleinden" in labels && "systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.17"
-            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
+            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.18"
-            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
+            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.19"
             if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "transparantierisico" in labels'
       - answer: Nee
@@ -800,21 +804,25 @@ questions:
           - nextConclusionId: "12.6"
             if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.7"
-            if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.12"
             if: '"AI-systeem voor algemene doeleinden" in labels && "systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.13"
-            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
+            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.14"
-            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
+            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.15"
             if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.20"
             if: '"AI-model voor algemene doeleinden" in labels && "systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.21"
-            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
+            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.22"
-            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
+            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.23"
             if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "transparantierisico" in labels'
       - answer: Nee

--- a/frontend/public/decision-tree.yaml
+++ b/frontend/public/decision-tree.yaml
@@ -763,21 +763,21 @@ questions:
           - nextConclusionId: "12.4"
             if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.5"
-            if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.8"
             if: '"AI-systeem voor algemene doeleinden" in labels && "systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.9"
-            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.10"
-            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.11"
             if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.16"
             if: '"AI-model voor algemene doeleinden" in labels && "systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.17"
-            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.18"
-            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.19"
             if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "transparantierisico" in labels'
       - answer: Nee
@@ -800,21 +800,21 @@ questions:
           - nextConclusionId: "12.6"
             if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.7"
-            if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem" in labels && "geen hoog-risico AI" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.12"
             if: '"AI-systeem voor algemene doeleinden" in labels && "systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.13"
-            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.14"
-            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-systeem voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.15"
             if: '"AI-systeem voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.20"
             if: '"AI-model voor algemene doeleinden" in labels && "systeemrisico" in labels && "transparantierisico" in labels'
           - nextConclusionId: "12.21"
-            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.22"
-            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && "geen transparantierisico" in labels'
+            if: '"AI-model voor algemene doeleinden" in labels  && "systeemrisico" in labels && ("geen transparantierisico" in labels || "open-source" in labels)'
           - nextConclusionId: "12.23"
             if: '"AI-model voor algemene doeleinden" in labels && "geen systeemrisico" in labels && "transparantierisico" in labels'
       - answer: Nee


### PR DESCRIPTION
# Description

Fix referencing labels to open-source conclusions to make sure that the redirects include all open-source models. Open-source models, according to this decision tree,  automatically have no transparency risk. 


Resolves #
