### PR TITLE
Update codeowners in order for the dependabot to automerge bumps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,10 @@
 
 decision-tree.yaml @ruthkoole
 categories.yaml @ruthkoole
+
+# excluded files so github actions bot can auto update dependencies
+#  see https://github.com/orgs/community/discussions/23064
+.github/workflows/*
+.devcontainer/devcontainer.json
+.pre-commit-config.yaml
+frontend/package.json


### PR DESCRIPTION
# Description

In order for the dependabot to auto update minor updates, the version files needs to be excluded from the codeowners, so no review is needed and dependabot can automerge.

Link all GitHub issues fixed by this PR.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

