### PR TITLE
Fix role labels 

### DIFF
--- a/decision-tree.yaml
+++ b/decision-tree.yaml
@@ -478,7 +478,7 @@ questions:
     answers:
       - answer: Ja
         labels:
-          - "aanbieder + gebruiksverantwoordelijke"
+          - "aanbieder"
         redirects:
           - nextConclusionId: "14.0.1"
             if: '"AI-systeem" in labels && "hoog-risico AI" in labels && "transparantieverplichtingen" in labels'


### PR DESCRIPTION
# Description

In this PR:
- Assign 2 separate labels in the case that the (GP)AI-system is both for 'gebruiksverantwoordelijke' and 'aanbieder'

Link all GitHub issues fixed by this PR.
Make sure to first open an issue, get community approval and only then create Pull Request to resolve it.
All Pull Requests must have an issue attached to them

Resolves #
