### PR TITLE
Change package deploy location to GitHub release instead of NPM

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,11 +1,11 @@
-name: Build Node.js Package and Publish to Github Packages
+name: Build Node.js Package and Publish Assets
 
 on:
   release:
     types: [created]
 
 jobs:
-  publish-gpr:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -15,16 +15,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org/
-
-
-      - name: Change version number from release
-        run: |
-          sed -i 's|"version": .*$|"version": "${{ github.event.release.tag_name }}",|g' frontend/package.json
-
       - run: npm install --prefix frontend
       - run: npm run build --prefix frontend
-      - run: npm run prepub --prefix frontend
-      - run: npm publish ./frontend/dist --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPMJS_ACCESS_TOKEN}}
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/index.js
+            LICENSE.md

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Om door de beslisboom te lopen is een visualizatie tool gemaakt. Met deze tool k
 
 ### Frontend locaal draaien
 
-Om de development omgeving te standariseren maken we gebruik van [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started).
+Om de development omgeving te standaardiseren maken we gebruik van [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started).
 
-Als u in de devcontainer zit kunt u de volgende commandos uitvoeren. Voordat dit kan gaat u eerst in de frontend/ folder staan met een terminal.
+Als u in de devcontainer zit kunt u de volgende commando's uitvoeren. Voordat dit kan gaat u eerst in de frontend/ folder staan met een terminal.
 
 Start de tool:
 
@@ -143,7 +143,7 @@ kubectl apply -k infra/
 
 ## Validatie schema
 
-Door het volgende script te runnen, kunt u controlen of het bestand decision-tree.yaml en het bestand definitions.yaml (technisch) valide zijn. Eventuele (syntax)fouten worden hiermee aangegeven.
+Door het volgende script te runnen, kunt u controleren of het bestand decision-tree.yaml en het bestand definitions.yaml (technisch) valide zijn. Eventuele (syntax)fouten worden hiermee aangegeven.
 
 ```sh
 ./script/validate --file_pairs schemas/schema_decision_tree.json:decision-tree.yaml schemas/schema_definitions.json:definitions.yaml


### PR DESCRIPTION
# Description

Instead of an NPM package, we create a javascript file als release asset in GitHub.

Resolves #192 
