### PR TITLE
Not hashing the fonts in the build

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
             output: {
                 dir: './dist',
                 entryFileNames: 'index.js',
+                assetFileNames: `assets/[name].[ext]`
             }
         }
     },


### PR DESCRIPTION
# Description

We want the build to not have the dependency of a hashed font type, so we remove the hash behind the font.woff in the build through changing the vite config.

Resolves #192 
