### PR TITLE
fix: release-assets worden weer gepubliceerd (index.js ontbreekt sinds v1.2.16)

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -2,26 +2,54 @@ name: Build Node.js Package and Publish Assets
 
 on:
   release:
-    types: [created]
+    # "published" vuurt ook wanneer een release vanuit een draft wordt
+    # gepubliceerd; "created" deed dat niet, waardoor v1.2.16 en v1.2.24
+    # helemaal geen run kregen.
+    types: [published]
+  # Maakt het mogelijk de asset achteraf alsnog voor een bestaande tag te
+  # publiceren, zonder de release opnieuw aan te maken.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag waarvoor de assets gebouwd worden (bijv. v1.2.24)"
+        required: true
+        type: string
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
-      contents: read
+      # Nodig om release-assets te uploaden met de standaard GITHUB_TOKEN.
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      # decision-tree.json en categories.json zijn build-artefacten: de YAML's
+      # in de repo-root zijn de bron. Zonder deze stappen wordt de asset
+      # gebouwd op de (verouderde) ingecheckte JSON en wijkt hij af van het
+      # container-image dat build.yaml publiceert.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip3 install -r requirements.txt
+      - name: Build decision-tree.json
+        run: python script/inject_definitions_in_decision_tree.py
+      - name: Build categories.json
+        run: python script/convert_categories.py
+
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - run: npm install --prefix frontend
+          node-version: 22
+      - run: npm ci --prefix frontend
       - run: npm run build --prefix frontend
+
       - name: Publish release assets
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_UPDATE_RELEASE }}
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: |
             frontend/dist/index.js
             LICENSE.md


### PR DESCRIPTION
## Waarom

Sinds **v1.2.16** verschijnt er geen `index.js` meer als release-asset. Het Algoritmekader embedt die asset rechtstreeks en zit daardoor nog vast op **v1.2.15** (juli 2025).

Drie onafhankelijke oorzaken, alle drie hier geadresseerd:

### 1. De trigger mist draft-releases
`release: types: [created]` vuurt niet wanneer een release vanuit een **draft** wordt gepubliceerd. Voor v1.2.16 en v1.2.24 kreeg deze workflow daardoor helemaal **geen run** — terwijl `build.yaml` (die al op `published` staat) wel netjes draaide en het container-image publiceerde.

| tag | build.yaml | release-package.yml |
|---|---|---|
| v1.2.24 | ✅ success | — geen run |
| v1.2.23 | ✅ success | ❌ failure |
| v1.2.16 | ✅ success | — geen run |

→ nu `types: [published]`.

### 2. De runs die wél startten, faalden vroeg
v1.2.17 t/m v1.2.23 faalden binnen **~40 seconden** — ruim voor `npm run build` klaar kan zijn. Dat past op het npm/eslint peer-conflict dat in v1.2.24 is opgelost (#1045). De logs zijn inmiddels verlopen (410), dus dat is niet meer hard te verifiëren. Met v1.2.24 slagen `npm ci` en `npm run build` weer.

### 3. De asset werd op verouderde JSON gebouwd
`build.yaml` regenereert `decision-tree.json` en `categories.json` uit de YAML-bron vóór de docker-build; deze workflow deed dat niet en bouwde op de ingecheckte JSON. De gepubliceerde asset week daardoor **inhoudelijk** af van het container-image — bijvoorbeeld een andere bron-URL bij "Aandacht voor Algoritmes":

```
asset : rekenkamer.nl/onderwerpen/algoritmes/documenten/rapporten/2021/01/26/...
image : rekenkamer.nl/documenten/2021/01/26/...
```

Dat gold ook al voor de v1.2.15-asset die het Algoritmekader nu embedt. De generatiestappen staan nu ook hier.

## Verder

- `GITHUB_TOKEN` + `permissions: contents: write` in plaats van de PAT `GH_PAT_UPDATE_RELEASE` (laatst geroteerd 2024-10-22 — PAT's verlopen stil, en hier is geen PAT voor nodig).
- `node-version: 22`, gelijk aan `frontend/Dockerfile` (was 20).
- `npm ci` in plaats van `npm install`, gelijk aan de Dockerfile.
- **`workflow_dispatch` met een `tag`-input**, zodat de asset voor een bestaande tag alsnog gepubliceerd kan worden — nodig om v1.2.24 te repareren zonder de release opnieuw aan te maken.

## Verificatie

Lokaal op tag v1.2.24 met exact deze stappen gebouwd. Het resultaat is **byte-identiek** (3.837.284 bytes) aan `/usr/share/nginx/html/index.js` in `ghcr.io/minbzk/ai-verordening-beslishulp:1.2.24`:

```
opnieuw gebouwd: 3837284 | image: 3837284
✅ BYTE-IDENTIEK aan de container-bundle
```

Zonder de generatiestappen (stap 3) wijkt hij 336 bytes af.

## Na merge

`workflow_dispatch` draaien met tag `v1.2.24`, zodat de asset alsnog bij die release komt te staan.
